### PR TITLE
fix(bundles): use the freshest external bundle service

### DIFF
--- a/api/DEV-CHANGELOG.md
+++ b/api/DEV-CHANGELOG.md
@@ -11,6 +11,7 @@
 
 # Bug fixes
 
+- Fixed patch bundle discovery preferring stale primary results by selecting the newest available data, falling back to the dev service, and importing bundles through the v3 API
 - Fixed saved patched apps installed through Shizuku-based custom installers showing Shell instead of the selected installer
 - Fixed pre-release updates not being detected for some patch bundles imported through GitHub or GitLab URLs
 - Fixed patch bundle tabs showing inaccurate counts by displaying selected and available patches as a selected/total value

--- a/app/src/main/java/app/urv/manager/MainActivity.kt
+++ b/app/src/main/java/app/urv/manager/MainActivity.kt
@@ -787,8 +787,19 @@ private fun ReVancedManager(
         composable<PatchBundleDiscovery> {
             PatchBundleDiscoveryScreen(
                 onBackClick = navController::popBackStack,
-                onViewPatches = { bundleId ->
-                    navController.navigate(PatchBundleDiscoveryPatches(bundleId))
+                onViewPatches = { bundle ->
+                    navController.navigate(
+                        PatchBundleDiscoveryPatches(
+                            bundleId = bundle.bundleId,
+                            apiHost = bundle.apiHost,
+                            sourceUrl = bundle.sourceUrl,
+                            version = bundle.version,
+                            isPrerelease = bundle.isPrerelease,
+                            patchCount = bundle.patchCount,
+                            ownerName = bundle.ownerName,
+                            repoName = bundle.repoName
+                        )
+                    )
                 }
             )
         }
@@ -797,6 +808,13 @@ private fun ReVancedManager(
             val data = it.toRoute<PatchBundleDiscoveryPatches>()
             PatchBundleDiscoveryPatchesScreen(
                 bundleId = data.bundleId,
+                apiHost = data.apiHost,
+                sourceUrl = data.sourceUrl,
+                version = data.version,
+                isPrerelease = data.isPrerelease,
+                patchCount = data.patchCount,
+                ownerName = data.ownerName,
+                repoName = data.repoName,
                 onBackClick = navController::popBackStack
             )
         }

--- a/app/src/main/java/app/urv/manager/domain/bundles/RemotePatchBundle.kt
+++ b/app/src/main/java/app/urv/manager/domain/bundles/RemotePatchBundle.kt
@@ -2,6 +2,7 @@ package app.urv.manager.domain.bundles
 
 import app.urv.manager.domain.manager.PreferencesManager
 import app.urv.manager.network.api.ExternalBundlesApi
+import app.urv.manager.network.api.ExternalBundlesEndpoints
 import app.urv.manager.network.api.ReVancedAPI
 import app.urv.manager.network.dto.ExternalBundleSnapshot
 import app.urv.manager.network.dto.GitHubAsset
@@ -23,9 +24,12 @@ import io.ktor.client.statement.bodyAsChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import io.ktor.http.Url
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
@@ -861,7 +865,7 @@ class ExternalGraphqlPatchBundle(
         val repo: String?,
         val prerelease: Boolean?,
         val hasExplicitChannel: Boolean,
-        val isV2LatestEndpoint: Boolean
+        val isLatestApiEndpoint: Boolean
     )
     private data class HistorySource(
         val owner: String,
@@ -883,12 +887,33 @@ class ExternalGraphqlPatchBundle(
         } else {
             metadata.isPrerelease ?: endpointMetadata.prerelease
         }
-        val endpointAsset = if (endpointMetadata.hasExplicitChannel && endpointMetadata.isV2LatestEndpoint) {
-            http.request<ReVancedAsset> { url(endpoint) }.getOrNull()
-        } else {
-            null
+        val trackLatestAcrossChannels = owner.isNotBlank() && repo.isNotBlank() && prerelease == null
+        val (endpointAsset, latestFromServices) = coroutineScope {
+            val endpointDeferred = async {
+                if (endpointMetadata.hasExplicitChannel && endpointMetadata.isLatestApiEndpoint) {
+                    withTimeoutOrNull(ExternalBundlesEndpoints.HOST_QUERY_TIMEOUT_MS) {
+                        http.request<ReVancedAsset> { url(endpoint) }.getOrNull()
+                    }
+                } else {
+                    null
+                }
+            }
+            val latestDeferred = async {
+                findLatestExternalSnapshot(owner, repo, prerelease)
+            }
+            endpointDeferred.await() to latestDeferred.await()
         }
         if (endpointAsset != null) {
+            val latestCreatedAt = latestFromServices?.let { parseInstant(it.createdAt) }
+            val endpointCreatedAt = endpointAsset.createdAt.toInstant(TimeZone.UTC)
+            if (latestFromServices != null && latestCreatedAt != null && latestCreatedAt > endpointCreatedAt) {
+                metadata = metadataFromSnapshot(
+                    snapshot = latestFromServices,
+                    preserveChannelSelection = trackLatestAcrossChannels
+                )
+                ExternalBundleMetadataStore.write(directory, metadata)
+                return@withContext snapshotToAsset(latestFromServices)
+            }
             metadata = metadata.copy(
                 downloadUrl = endpointAsset.downloadUrl,
                 signatureDownloadUrl = endpointAsset.signatureDownloadUrl,
@@ -923,21 +948,8 @@ class ExternalGraphqlPatchBundle(
                 return@withContext officialAsset
             }
         }
-        val trackLatestAcrossChannels = owner.isNotBlank() && repo.isNotBlank() && prerelease == null
-        val latest = if (owner.isNotBlank() && repo.isNotBlank()) {
-            if (prerelease != null) {
-                api.getLatestBundle(owner, repo, prerelease).getOrNull()
-            } else {
-                api.getLatestBundleAny(owner, repo).getOrNull()
-                    ?: run {
-                        val latestRelease = api.getLatestBundle(owner, repo, prerelease = false).getOrNull()
-                        val latestPrerelease = api.getLatestBundle(owner, repo, prerelease = true).getOrNull()
-                        pickLatestSnapshot(latestRelease, latestPrerelease)
-                    }
-            }
-        } else {
-            null
-        } ?: api.getBundleById(metadata.bundleId).getOrNull()
+        val latest = latestFromServices
+            ?: api.getBundleById(metadata.bundleId, externalBundlesHost()).getOrNull()
         if (latest != null) {
             metadata = metadataFromSnapshot(
                 snapshot = latest,
@@ -946,6 +958,24 @@ class ExternalGraphqlPatchBundle(
             ExternalBundleMetadataStore.write(directory, metadata)
         }
         snapshotToAsset(latest)
+    }
+
+    private suspend fun findLatestExternalSnapshot(
+        owner: String,
+        repo: String,
+        prerelease: Boolean?
+    ): ExternalBundleSnapshot? {
+        if (owner.isBlank() || repo.isBlank()) return null
+        return if (prerelease != null) {
+            api.getLatestBundle(owner, repo, prerelease).getOrNull()
+        } else {
+            api.getLatestBundleAny(owner, repo).getOrNull()
+                ?: run {
+                    val latestRelease = api.getLatestBundle(owner, repo, prerelease = false).getOrNull()
+                    val latestPrerelease = api.getLatestBundle(owner, repo, prerelease = true).getOrNull()
+                    pickLatestSnapshot(latestRelease, latestPrerelease)
+                }
+        }
     }
 
     override suspend fun getHistoricalChangelogEntries(limit: Int) = withContext(Dispatchers.IO) {
@@ -1119,7 +1149,7 @@ class ExternalGraphqlPatchBundle(
         val metadataOwner = metadata.ownerName?.trim().takeIf { !it.isNullOrBlank() }
         val metadataRepo = metadata.repoName?.trim().takeIf { !it.isNullOrBlank() }
         val snapshot = metadata.bundleId.takeIf { it > 0 }?.let { bundleId ->
-            api.getBundleById(bundleId).getOrNull()
+            api.getBundleById(bundleId, externalBundlesHost()).getOrNull()
         }
         val snapshotOwner = snapshot?.ownerName?.trim().takeIf { !it.isNullOrBlank() }
         val snapshotRepo = snapshot?.repoName?.trim().takeIf { !it.isNullOrBlank() }
@@ -1180,6 +1210,28 @@ class ExternalGraphqlPatchBundle(
         for (candidate in candidates) {
             val parsed = runCatching { Url(candidate) }.getOrNull() ?: continue
             val segments = parsed.encodedPath.trim('/').split('/').filter { it.isNotBlank() }
+            if (parsed.encodedPath.equals(ExternalBundlesEndpoints.V3_BUNDLE_PATH, ignoreCase = true)) {
+                val sourceUrl = parsed.parameters["source_url"]
+                val source = sourceUrl?.let { runCatching { Url(it) }.getOrNull() }
+                val sourceSegments = source?.encodedPath
+                    ?.trim('/')
+                    ?.split('/')
+                    ?.filter { it.isNotBlank() }
+                    .orEmpty()
+                val (hasExplicitChannel, prerelease) = when (parsed.parameters["channel"]?.lowercase()) {
+                    "any" -> true to null
+                    "stable" -> true to false
+                    "prerelease" -> true to true
+                    else -> false to null
+                }
+                return EndpointMetadata(
+                    owner = sourceSegments.dropLast(1).joinToString("/").takeIf { it.isNotBlank() },
+                    repo = sourceSegments.lastOrNull(),
+                    prerelease = prerelease,
+                    hasExplicitChannel = hasExplicitChannel,
+                    isLatestApiEndpoint = parsed.parameters["version"].equals("latest", ignoreCase = true)
+                )
+            }
             if (segments.size >= 5 &&
                 segments[0].equals("api", ignoreCase = true) &&
                 (segments[1].equals("v1", ignoreCase = true) || segments[1].equals("v2", ignoreCase = true)) &&
@@ -1206,7 +1258,7 @@ class ExternalGraphqlPatchBundle(
                     repo = repo,
                     prerelease = prerelease,
                     hasExplicitChannel = hasExplicitChannel,
-                    isV2LatestEndpoint = segments[1].equals("v2", ignoreCase = true) &&
+                    isLatestApiEndpoint = segments[1].equals("v2", ignoreCase = true) &&
                         segments.getOrNull(5).equals("latest", ignoreCase = true)
                 )
             }
@@ -1216,8 +1268,16 @@ class ExternalGraphqlPatchBundle(
             repo = null,
             prerelease = null,
             hasExplicitChannel = false,
-            isV2LatestEndpoint = false
+            isLatestApiEndpoint = false
         )
+    }
+
+    private fun externalBundlesHost(): String {
+        for (candidate in listOfNotNull(endpoint, metadata.downloadUrl)) {
+            val host = runCatching { Url(candidate).host }.getOrNull() ?: continue
+            if (ExternalBundlesEndpoints.isExternalBundlesHost(host)) return host
+        }
+        return ExternalBundlesEndpoints.STABLE_HOST
     }
 
     private fun safeArtifactUrl(raw: String?): String? {
@@ -1230,13 +1290,10 @@ class ExternalGraphqlPatchBundle(
     private fun isExternalBundleApiEndpoint(raw: String): Boolean {
         val parsed = runCatching { Url(raw) }.getOrNull() ?: return false
         val host = parsed.host.lowercase()
-        val isExternalBundlesHost = host == "revanced-external-bundles.brosssh.com" ||
-            host == "revanced-external-bundles-dev.brosssh.com"
+        val isExternalBundlesHost = ExternalBundlesEndpoints.isExternalBundlesHost(host)
         if (!isExternalBundlesHost) return false
         val pathNoQuery = parsed.encodedPath.substringBefore('?').substringBefore('#')
-        return pathNoQuery.startsWith("/api/v1/bundle/") ||
-            pathNoQuery.startsWith("/api/v2/bundle/") ||
-            pathNoQuery.startsWith("/bundles/id")
+        return ExternalBundlesEndpoints.isBundleApiPath(pathNoQuery)
     }
 
     private fun parseCreatedAt(raw: String?): LocalDateTime {
@@ -1271,6 +1328,7 @@ class ExternalGraphqlPatchBundle(
         val trimmed = raw?.trim().orEmpty()
         if (trimmed.isEmpty()) return null
         return runCatching { Instant.parse(trimmed) }.getOrNull()
+            ?: runCatching { LocalDateTime.parse(trimmed).toInstant(TimeZone.UTC) }.getOrNull()
     }
 
     private fun pickNewestOfficialAsset(

--- a/app/src/main/java/app/urv/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/urv/manager/domain/repository/PatchBundleRepository.kt
@@ -34,6 +34,7 @@ import app.urv.manager.domain.bundles.PatchBundleSource.Extensions.asRemoteOrNul
 import app.urv.manager.domain.bundles.PatchBundleSource.Extensions.isDefault
 import app.urv.manager.domain.bundles.RepositoryBundleSettings
 import app.urv.manager.domain.bundles.RepositoryBundleSettingsStore
+import app.urv.manager.network.api.ExternalBundlesEndpoints
 import app.urv.manager.network.dto.ExternalBundleSnapshot
 import app.urv.manager.domain.manager.PreferencesManager
 import app.urv.manager.patcher.morphe.MorpheRuntimeBridge
@@ -951,24 +952,18 @@ class PatchBundleRepository(
     }
 
     fun discoveryImportKey(bundle: ExternalBundleSnapshot, preferLatestAcrossChannels: Boolean = false): String {
-        if (bundle.bundleId > 0) {
-            val channel = if (preferLatestAcrossChannels) {
-                "latest"
-            } else if (bundle.isPrerelease) {
-                "prerelease"
-            } else {
-                "release"
-            }
-            return "${bundle.bundleId}|$channel"
-        }
+        val sourceUrl = bundle.sourceUrl.trim().trimEnd('/').lowercase(Locale.US)
         val owner = bundle.ownerName.trim().lowercase(Locale.US)
         val repo = bundle.repoName.trim().lowercase(Locale.US)
+        val apiHost = bundle.apiHost.trim().lowercase(Locale.US)
+            .takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
         val base = when {
+            sourceUrl.isNotBlank() -> sourceUrl
             owner.isNotBlank() || repo.isNotBlank() ->
                 listOf(owner, repo).filter { it.isNotBlank() }.joinToString("/")
-            bundle.sourceUrl.isNotBlank() -> bundle.sourceUrl.trim().lowercase(Locale.US)
             !bundle.downloadUrl.isNullOrBlank() ->
                 bundle.downloadUrl.trim().lowercase(Locale.US)
+            bundle.bundleId > 0 -> "${apiHost ?: "unknown-host"}|id=${bundle.bundleId}"
             else -> "unknown"
         }
         val channel = if (preferLatestAcrossChannels) {
@@ -2393,19 +2388,23 @@ class PatchBundleRepository(
     ): String {
         val owner = bundle.ownerName.trim()
         val repo = bundle.repoName.trim()
-        if (owner.isNotBlank() && repo.isNotBlank()) {
-            val channel = when {
-                preferLatestAcrossChannels -> "any"
-                bundle.isPrerelease -> "prerelease"
-                else -> "stable"
-            }
-            return "https://revanced-external-bundles.brosssh.com/api/v2/bundle/$owner/$repo/latest?channel=$channel"
-        }
-        return externalBundleEndpoint(bundle.bundleId)
+        val sourceUrl = bundle.sourceUrl.trim().takeIf { it.isNotBlank() }
+            ?: if (owner.isNotBlank() && repo.isNotBlank()) "https://github.com/$owner/$repo" else ""
+        val host = bundle.apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+            ?: ExternalBundlesEndpoints.STABLE_HOST
+        ExternalBundlesEndpoints.latestBundleUrl(
+            host = host,
+            sourceUrl = sourceUrl,
+            prerelease = if (preferLatestAcrossChannels) null else bundle.isPrerelease
+        )?.let { return it }
+        return externalBundleEndpoint(bundle.bundleId, host)
     }
 
-    private fun externalBundleEndpoint(bundleId: Int): String =
-        "https://revanced-external-bundles.brosssh.com/bundles/id?id=$bundleId"
+    private fun externalBundleEndpoint(bundleId: Int, apiHost: String): String {
+        val host = apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+            ?: ExternalBundlesEndpoints.STABLE_HOST
+        return "https://$host/bundles/id?id=$bundleId"
+    }
 
     private fun validateRemoteBundleUrl(input: String): String {
         val trimmed = input.trim()
@@ -2418,14 +2417,9 @@ class PatchBundleRepository(
         val pathNoQuery = parsed.encodedPath.substringBefore('?').substringBefore('#')
         val isJson = pathNoQuery.endsWith(".json", ignoreCase = true)
         val host = parsed.host.lowercase(Locale.US)
-        val isExternalBundlesHost = host == "revanced-external-bundles.brosssh.com" ||
-            host == "revanced-external-bundles-dev.brosssh.com"
+        val isExternalBundlesHost = ExternalBundlesEndpoints.isExternalBundlesHost(host)
         val isExternalBundlesEndpoint = isExternalBundlesHost &&
-            (
-                pathNoQuery.startsWith("/api/v1/bundle/") ||
-                    pathNoQuery.startsWith("/api/v2/bundle/") ||
-                    pathNoQuery.startsWith("/bundles/id")
-                )
+            ExternalBundlesEndpoints.isBundleApiPath(pathNoQuery)
         if (!isJson && !isExternalBundlesEndpoint) {
             throw IllegalArgumentException(
                 app.getString(R.string.patch_bundle_url_invalid_json_or_external)
@@ -2446,8 +2440,7 @@ class PatchBundleRepository(
         }
 
         val host = parsed.host.lowercase(Locale.US)
-        val isExternalBundlesHost = host == "revanced-external-bundles.brosssh.com" ||
-            host == "revanced-external-bundles-dev.brosssh.com"
+        val isExternalBundlesHost = ExternalBundlesEndpoints.isExternalBundlesHost(host)
         if (!isExternalBundlesHost) {
             throw IllegalArgumentException(
                 app.getString(R.string.patch_bundle_url_invalid_external)
@@ -2504,14 +2497,8 @@ class PatchBundleRepository(
 
         val normalizedPath = "/" + pathSegments.joinToString("/")
         val pathNoQuery = normalizedPath.substringBefore('?').substringBefore('#')
-        if (host.equals("revanced-external-bundles.brosssh.com", ignoreCase = true) ||
-            host.equals("revanced-external-bundles-dev.brosssh.com", ignoreCase = true)
-        ) {
-            if (
-                pathNoQuery.startsWith("/bundles/id") ||
-                pathNoQuery.startsWith("/api/v1/bundle/") ||
-                pathNoQuery.startsWith("/api/v2/bundle/")
-            ) {
+        if (ExternalBundlesEndpoints.isExternalBundlesHost(host)) {
+            if (ExternalBundlesEndpoints.isBundleApiPath(pathNoQuery)) {
                 val query = parsed.encodedQuery.takeIf { it.isNotEmpty() }?.let { "?$it" }.orEmpty()
                 return "https://$host$normalizedPath$query"
             }

--- a/app/src/main/java/app/urv/manager/network/api/ExternalBundlesApi.kt
+++ b/app/src/main/java/app/urv/manager/network/api/ExternalBundlesApi.kt
@@ -22,11 +22,9 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toInstant
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -43,6 +41,10 @@ data class ExternalBundlesPage(
 class ExternalBundlesApi(
     private val client: HttpService,
 ) {
+    private val endpointSelectionMutex = Mutex()
+    @Volatile
+    private var cachedEndpointSelection: CachedEndpointSelection? = null
+
     suspend fun getBundles(
         packageNameQuery: String? = null,
         limit: Int = DEFAULT_PAGE_SIZE,
@@ -57,15 +59,10 @@ class ExternalBundlesApi(
                 variables
             ).transform { data -> data.toDiscoveryPage(endpoint) }
         }
-        val responses = queryBoth<BundlesQueryData>(BUNDLES_QUERY, variables)
-        return selectFreshestResponse(
-            responses = responses,
-            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
-            transform = { data, endpoint ->
-                data.toDiscoveryPage(endpoint)
-            },
-            preferDev = ::isDevDiscoveryResponseFresher
-        )
+        return queryPreferred<BundlesQueryData, ExternalBundlesPage>(
+            BUNDLES_QUERY,
+            variables
+        ) { data, endpoint -> data.toDiscoveryPage(endpoint) }
     }
 
     suspend fun getBundleById(
@@ -100,14 +97,12 @@ class ExternalBundlesApi(
             put("repo", JsonPrimitive(trimmedRepo))
             put("prerelease", JsonPrimitive(prerelease))
         }
-        val responses = queryBoth<BundlesQueryData>(BUNDLE_LATEST_QUERY, variables)
-        return selectFreshestResponse(
-            responses = responses,
-            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
-            transform = { data, endpoint ->
-                data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
-            }
-        )
+        return queryPreferred<BundlesQueryData, ExternalBundleSnapshot?>(
+            BUNDLE_LATEST_QUERY,
+            variables
+        ) { data, endpoint ->
+            data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
+        }
     }
 
     suspend fun getLatestBundleAny(
@@ -123,14 +118,12 @@ class ExternalBundlesApi(
             put("owner", JsonPrimitive(trimmedOwner))
             put("repo", JsonPrimitive(trimmedRepo))
         }
-        val responses = queryBoth<BundlesQueryData>(BUNDLE_LATEST_ANY_QUERY, variables)
-        return selectFreshestResponse(
-            responses = responses,
-            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
-            transform = { data, endpoint ->
-                data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
-            }
-        )
+        return queryPreferred<BundlesQueryData, ExternalBundleSnapshot?>(
+            BUNDLE_LATEST_ANY_QUERY,
+            variables
+        ) { data, endpoint ->
+            data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
+        }
     }
 
     suspend fun getBundleHistory(
@@ -146,42 +139,25 @@ class ExternalBundlesApi(
         }
 
         val targetLimit = limit.coerceAtLeast(1)
-        val responses = coroutineScope {
-            val stable = async {
-                getBundleHistory(STABLE_ENDPOINT, trimmedOwner, trimmedRepo, prerelease, targetLimit)
-            }
-            val dev = async {
-                getBundleHistory(DEV_ENDPOINT, trimmedOwner, trimmedRepo, prerelease, targetLimit)
-            }
-            EndpointResponses(stable.await(), dev.await())
-        }
-        val stable = responses.stable
-        val dev = responses.dev
-        return when {
-            stable is APIResponse.Success && dev is APIResponse.Success -> {
-                val history = (stable.data + dev.data)
-                    .sortedWith { left, right ->
-                        when {
-                            isNewer(left.createdAt, right.createdAt) -> -1
-                            isNewer(right.createdAt, left.createdAt) -> 1
-                            else -> 0
-                        }
-                    }
-                    .distinctBy { snapshot ->
-                        listOf(
-                            snapshot.sourceUrl.trim().lowercase(),
-                            snapshot.version.trim().lowercase(),
-                            snapshot.isPrerelease.toString()
-                        ).joinToString("|")
-                    }
-                    .take(targetLimit)
-                APIResponse.Success(history)
-            }
-            stable is APIResponse.Success -> stable
-            dev is APIResponse.Success -> dev
-            dev is APIResponse.Error -> APIResponse.Error(dev.error)
-            dev is APIResponse.Failure -> APIResponse.Failure(dev.error)
-            else -> APIResponse.Success(emptyList())
+        val preferredEndpoint = preferredEndpoint()
+        val preferredResponse = getBundleHistory(
+            preferredEndpoint,
+            trimmedOwner,
+            trimmedRepo,
+            prerelease,
+            targetLimit
+        )
+        if (preferredResponse is APIResponse.Success) return preferredResponse
+
+        val fallbackEndpoint = alternateEndpoint(preferredEndpoint)
+        return getBundleHistory(
+            fallbackEndpoint,
+            trimmedOwner,
+            trimmedRepo,
+            prerelease,
+            targetLimit
+        ).also { response ->
+            if (response is APIResponse.Success) cacheDegradedEndpoint(fallbackEndpoint)
         }
     }
 
@@ -477,77 +453,124 @@ class ExternalBundlesApi(
 
     private data class Endpoint(
         val host: String,
-        val graphqlUrl: String
+        val graphqlUrl: String,
+        val apiDocumentUrl: String
     )
 
-    private data class EndpointResponses<T>(
-        val stable: APIResponse<T>,
-        val dev: APIResponse<T>
-    )
-
-    private data class EndpointSuccess<T>(
+    private data class ResolvedEndpointSelection(
         val endpoint: Endpoint,
-        val data: T
+        val cacheDurationMillis: Long
     )
 
-    private suspend inline fun <reified T> queryBoth(
+    private data class CachedEndpointSelection(
+        val endpoint: Endpoint,
+        val resolvedAtMillis: Long,
+        val cacheDurationMillis: Long
+    )
+
+    @Serializable
+    private data class ApiDocument(
+        val info: ApiInfo
+    )
+
+    @Serializable
+    private data class ApiInfo(
+        val version: String
+    )
+
+    private suspend inline fun <reified T, R> queryPreferred(
         query: String,
-        variables: JsonObject?
-    ): EndpointResponses<T> = coroutineScope {
-        val stable = async { graphqlWithDeadline<T>(STABLE_ENDPOINT.graphqlUrl, query, variables) }
-        val dev = async { graphqlWithDeadline<T>(DEV_ENDPOINT.graphqlUrl, query, variables) }
-        EndpointResponses(stable.await(), dev.await())
-    }
-
-    private fun <T, R> selectFreshestResponse(
-        responses: EndpointResponses<T>,
-        timestamp: (T) -> String?,
-        transform: (T, Endpoint) -> R,
-        preferDev: ((dev: T, stable: T) -> Boolean)? = null
+        variables: JsonObject?,
+        crossinline transform: (T, Endpoint) -> R
     ): APIResponse<R> {
-        val stable = responses.stable
-        val dev = responses.dev
-        val selected = when {
-            stable is APIResponse.Success && dev is APIResponse.Success -> {
-                val devIsFresher = preferDev?.invoke(dev.data, stable.data)
-                    ?: isNewer(timestamp(dev.data), timestamp(stable.data))
-                if (devIsFresher) {
-                    EndpointSuccess(DEV_ENDPOINT, dev.data)
-                } else {
-                    EndpointSuccess(STABLE_ENDPOINT, stable.data)
-                }
-            }
-            stable is APIResponse.Success -> EndpointSuccess(STABLE_ENDPOINT, stable.data)
-            dev is APIResponse.Success -> EndpointSuccess(DEV_ENDPOINT, dev.data)
-            else -> return when (dev) {
-                is APIResponse.Error -> APIResponse.Error(dev.error)
-                is APIResponse.Failure -> APIResponse.Failure(dev.error)
-                is APIResponse.Success -> APIResponse.Success(transform(dev.data, DEV_ENDPOINT))
-            }
+        val preferredEndpoint = preferredEndpoint()
+        val preferredResponse = graphqlWithDeadline<T>(
+            preferredEndpoint.graphqlUrl,
+            query,
+            variables
+        )
+        if (preferredResponse is APIResponse.Success) {
+            return APIResponse.Success(transform(preferredResponse.data, preferredEndpoint))
         }
-        return APIResponse.Success(transform(selected.data, selected.endpoint))
+
+        val fallbackEndpoint = alternateEndpoint(preferredEndpoint)
+        return graphqlWithDeadline<T>(fallbackEndpoint.graphqlUrl, query, variables)
+            .transform { data -> transform(data, fallbackEndpoint) }
+            .also { response ->
+                if (response is APIResponse.Success) cacheDegradedEndpoint(fallbackEndpoint)
+            }
     }
 
-    private fun isDevDiscoveryResponseFresher(
-        dev: BundlesQueryData,
-        stable: BundlesQueryData
-    ): Boolean {
-        val devBundle = dev.bundle.firstOrNull()
-        val stableBundle = stable.bundle.firstOrNull()
-        when {
-            devBundle != null && stableBundle == null -> return true
-            devBundle == null -> return false
-            isNewer(devBundle.createdAt, stableBundle?.createdAt) -> return true
-            isNewer(stableBundle?.createdAt, devBundle.createdAt) -> return false
+    private suspend fun preferredEndpoint(): Endpoint {
+        cachedEndpoint()?.let { return it }
+        endpointSelectionMutex.lock()
+        return try {
+            cachedEndpoint() ?: resolvePreferredEndpoint().let { selection ->
+                cachedEndpointSelection = CachedEndpointSelection(
+                    endpoint = selection.endpoint,
+                    resolvedAtMillis = monotonicMillis(),
+                    cacheDurationMillis = selection.cacheDurationMillis
+                )
+                selection.endpoint
+            }
+        } finally {
+            endpointSelectionMutex.unlock()
         }
+    }
 
-        val devRefresh = dev.refreshJobs.firstOrNull()
-        val stableRefresh = stable.refreshJobs.firstOrNull()
-        return isNewer(
-            newestTimestamp(devRefresh?.completedAt, devRefresh?.startedAt),
-            newestTimestamp(stableRefresh?.completedAt, stableRefresh?.startedAt)
+    private fun cachedEndpoint(): Endpoint? {
+        val selection = cachedEndpointSelection ?: return null
+        val ageMillis = monotonicMillis() - selection.resolvedAtMillis
+        return selection.endpoint.takeIf { ageMillis < selection.cacheDurationMillis }
+    }
+
+    private suspend fun cacheDegradedEndpoint(endpoint: Endpoint) {
+        endpointSelectionMutex.lock()
+        try {
+            cachedEndpointSelection = CachedEndpointSelection(
+                endpoint = endpoint,
+                resolvedAtMillis = monotonicMillis(),
+                cacheDurationMillis = DEGRADED_ENDPOINT_SELECTION_TTL_MS
+            )
+        } finally {
+            endpointSelectionMutex.unlock()
+        }
+    }
+
+    private suspend fun resolvePreferredEndpoint(): ResolvedEndpointSelection = coroutineScope {
+        val stableVersion = async { apiVersion(STABLE_ENDPOINT) }
+        val devVersion = async { apiVersion(DEV_ENDPOINT) }
+        val stableVersionValue = stableVersion.await()
+        val devVersionValue = devVersion.await()
+        val endpoint = endpointForHost(
+            ExternalBundlesEndpoints.preferredHost(stableVersionValue, devVersionValue)
+        ) ?: DEV_ENDPOINT
+        ResolvedEndpointSelection(
+            endpoint = endpoint,
+            cacheDurationMillis = if (stableVersionValue != null && devVersionValue != null) {
+                ENDPOINT_SELECTION_TTL_MS
+            } else {
+                DEGRADED_ENDPOINT_SELECTION_TTL_MS
+            }
         )
     }
+
+    private fun monotonicMillis(): Long = System.nanoTime() / 1_000_000L
+
+    private suspend fun apiVersion(endpoint: Endpoint): String? =
+        withTimeoutOrNull(ExternalBundlesEndpoints.HOST_QUERY_TIMEOUT_MS) {
+            when (val response = client.request<ApiDocument> {
+                method = HttpMethod.Get
+                url(endpoint.apiDocumentUrl)
+            }) {
+                is APIResponse.Success -> response.data.info.version.trim().takeIf(String::isNotBlank)
+                is APIResponse.Error,
+                is APIResponse.Failure -> null
+            }
+        }
+
+    private fun alternateEndpoint(endpoint: Endpoint): Endpoint =
+        if (endpoint == STABLE_ENDPOINT) DEV_ENDPOINT else STABLE_ENDPOINT
 
     private fun endpointForHost(host: String): Endpoint? = when {
         host.equals(STABLE_ENDPOINT.host, ignoreCase = true) -> STABLE_ENDPOINT
@@ -555,37 +578,19 @@ class ExternalBundlesApi(
         else -> null
     }
 
-    private fun isNewer(candidate: String?, baseline: String?): Boolean {
-        val candidateValue = candidate?.trim().takeIf { !it.isNullOrBlank() } ?: return false
-        val baselineValue = baseline?.trim().takeIf { !it.isNullOrBlank() } ?: return true
-        val candidateInstant = parseTimestamp(candidateValue)
-        val baselineInstant = parseTimestamp(baselineValue)
-        return if (candidateInstant != null && baselineInstant != null) {
-            candidateInstant > baselineInstant
-        } else {
-            candidateValue > baselineValue
-        }
-    }
-
-    private fun newestTimestamp(vararg values: String?): String? =
-        values.mapNotNull { it?.trim()?.takeIf(String::isNotBlank) }
-            .reduceOrNull { newest, candidate ->
-                if (isNewer(candidate, newest)) candidate else newest
-            }
-
-    private fun parseTimestamp(raw: String): Instant? =
-        runCatching { Instant.parse(raw) }.getOrNull()
-            ?: runCatching { LocalDateTime.parse(raw).toInstant(TimeZone.UTC) }.getOrNull()
-
     companion object {
         private val STABLE_ENDPOINT = Endpoint(
             host = ExternalBundlesEndpoints.STABLE_HOST,
-            graphqlUrl = "https://${ExternalBundlesEndpoints.STABLE_HOST}/hasura/v1/graphql"
+            graphqlUrl = "https://${ExternalBundlesEndpoints.STABLE_HOST}/hasura/v1/graphql",
+            apiDocumentUrl = "https://${ExternalBundlesEndpoints.STABLE_HOST}/api.json"
         )
         private val DEV_ENDPOINT = Endpoint(
             host = ExternalBundlesEndpoints.DEV_HOST,
-            graphqlUrl = "https://${ExternalBundlesEndpoints.DEV_HOST}/hasura/v1/graphql"
+            graphqlUrl = "https://${ExternalBundlesEndpoints.DEV_HOST}/hasura/v1/graphql",
+            apiDocumentUrl = "https://${ExternalBundlesEndpoints.DEV_HOST}/api.json"
         )
+        private const val ENDPOINT_SELECTION_TTL_MS = 15 * 60 * 1_000L
+        private const val DEGRADED_ENDPOINT_SELECTION_TTL_MS = 30 * 1_000L
         private const val BUNDLES_QUERY = """
             query BundleDiscovery(${"$"}where: bundle_bool_exp, ${"$"}limit: Int, ${"$"}offset: Int) {
               refresh_jobs(

--- a/app/src/main/java/app/urv/manager/network/api/ExternalBundlesApi.kt
+++ b/app/src/main/java/app/urv/manager/network/api/ExternalBundlesApi.kt
@@ -10,7 +10,6 @@ import app.urv.manager.network.dto.GraphqlRequest
 import app.urv.manager.network.dto.GraphqlResponse
 import app.urv.manager.network.dto.PatchNode
 import app.urv.manager.network.dto.RefreshJobNode
-import app.urv.manager.network.dto.RefreshJobsQueryData
 import app.urv.manager.network.service.HttpService
 import app.urv.manager.network.utils.APIFailure
 import app.urv.manager.network.utils.APIResponse
@@ -21,10 +20,25 @@ import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.io.IOException
+
+data class ExternalBundlesPage(
+    val bundles: List<ExternalBundleSnapshot>,
+    val apiHost: String,
+    val refreshJob: RefreshJobNode?
+)
 
 class ExternalBundlesApi(
     private val client: HttpService,
@@ -32,75 +46,42 @@ class ExternalBundlesApi(
     suspend fun getBundles(
         packageNameQuery: String? = null,
         limit: Int = DEFAULT_PAGE_SIZE,
-        offset: Int = 0
-    ): APIResponse<List<ExternalBundleSnapshot>> {
-        val stableVariables = buildBundleVariables(packageNameQuery, limit, offset)
-        val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLES_QUERY, stableVariables)
-        if (stableResponse is APIResponse.Success) {
-            return stableResponse.transform { data ->
-                data.bundle.map { it.toSnapshot(STABLE_BUNDLES_HOST) }
-            }
+        offset: Int = 0,
+        apiHost: String? = null
+    ): APIResponse<ExternalBundlesPage> {
+        val variables = buildBundleVariables(packageNameQuery, limit, offset)
+        endpointForHost(apiHost.orEmpty())?.let { endpoint ->
+            return graphqlWithDeadline<BundlesQueryData>(
+                endpoint.graphqlUrl,
+                BUNDLES_QUERY,
+                variables
+            ).transform { data -> data.toDiscoveryPage(endpoint) }
         }
-
-        val devVariables = buildBundleVariables(packageNameQuery, limit, offset)
-        val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLES_QUERY, devVariables)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                data.bundle.map { it.toSnapshot(DEV_BUNDLES_HOST) }
-            }
-        }
-
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-            is APIResponse.Success -> APIResponse.Success(emptyList())
-        }
+        val responses = queryBoth<BundlesQueryData>(BUNDLES_QUERY, variables)
+        return selectFreshestResponse(
+            responses = responses,
+            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
+            transform = { data, endpoint ->
+                data.toDiscoveryPage(endpoint)
+            },
+            preferDev = ::isDevDiscoveryResponseFresher
+        )
     }
 
-    suspend fun getBundleById(bundleId: Int): APIResponse<ExternalBundleSnapshot?> {
+    suspend fun getBundleById(
+        bundleId: Int,
+        apiHost: String = ExternalBundlesEndpoints.STABLE_HOST
+    ): APIResponse<ExternalBundleSnapshot?> {
         val variables = buildJsonObject {
             put("id", JsonPrimitive(bundleId))
         }
-        val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLE_BY_ID_QUERY, variables)
-        if (stableResponse is APIResponse.Success) {
-            return stableResponse.transform { data ->
-                data.bundle.firstOrNull()?.toSnapshot(STABLE_BUNDLES_HOST)
-            }
-        }
-
-        val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLE_BY_ID_QUERY, variables)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                data.bundle.firstOrNull()?.toSnapshot(DEV_BUNDLES_HOST)
-            }
-        }
-
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-            is APIResponse.Success -> APIResponse.Success(null)
-        }
-    }
-
-    suspend fun getLatestRefreshJob(): APIResponse<RefreshJobNode?> {
-        val stableResponse = graphql<RefreshJobsQueryData>(STABLE_GRAPHQL_URL, REFRESH_JOBS_QUERY, null)
-        if (stableResponse is APIResponse.Success) {
-            return stableResponse.transform { data ->
-                data.refreshJobs.firstOrNull()
-            }
-        }
-
-        val devResponse = graphql<RefreshJobsQueryData>(DEV_GRAPHQL_URL, REFRESH_JOBS_QUERY, null)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                data.refreshJobs.firstOrNull()
-            }
-        }
-
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-            is APIResponse.Success -> APIResponse.Success(null)
+        val endpoint = endpointForHost(apiHost) ?: STABLE_ENDPOINT
+        return graphqlWithDeadline<BundlesQueryData>(
+            endpoint.graphqlUrl,
+            BUNDLE_BY_ID_QUERY,
+            variables
+        ).transform { data ->
+            data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
         }
     }
 
@@ -119,30 +100,14 @@ class ExternalBundlesApi(
             put("repo", JsonPrimitive(trimmedRepo))
             put("prerelease", JsonPrimitive(prerelease))
         }
-        val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLE_LATEST_QUERY, variables)
-        if (stableResponse is APIResponse.Success) {
-            val stableSnapshot = stableResponse.data.bundle.firstOrNull()?.toSnapshot(STABLE_BUNDLES_HOST)
-            if (stableSnapshot != null) {
-                return APIResponse.Success(stableSnapshot)
+        val responses = queryBoth<BundlesQueryData>(BUNDLE_LATEST_QUERY, variables)
+        return selectFreshestResponse(
+            responses = responses,
+            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
+            transform = { data, endpoint ->
+                data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
             }
-        }
-
-        val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLE_LATEST_QUERY, variables)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                data.bundle.firstOrNull()?.toSnapshot(DEV_BUNDLES_HOST)
-            }
-        }
-
-        if (stableResponse is APIResponse.Success) {
-            return APIResponse.Success(null)
-        }
-
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-            is APIResponse.Success -> APIResponse.Success(null)
-        }
+        )
     }
 
     suspend fun getLatestBundleAny(
@@ -158,30 +123,14 @@ class ExternalBundlesApi(
             put("owner", JsonPrimitive(trimmedOwner))
             put("repo", JsonPrimitive(trimmedRepo))
         }
-        val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLE_LATEST_ANY_QUERY, variables)
-        if (stableResponse is APIResponse.Success) {
-            val stableSnapshot = stableResponse.data.bundle.firstOrNull()?.toSnapshot(STABLE_BUNDLES_HOST)
-            if (stableSnapshot != null) {
-                return APIResponse.Success(stableSnapshot)
+        val responses = queryBoth<BundlesQueryData>(BUNDLE_LATEST_ANY_QUERY, variables)
+        return selectFreshestResponse(
+            responses = responses,
+            timestamp = { data -> data.bundle.firstOrNull()?.createdAt },
+            transform = { data, endpoint ->
+                data.bundle.firstOrNull()?.toSnapshot(endpoint.host)
             }
-        }
-
-        val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLE_LATEST_ANY_QUERY, variables)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                data.bundle.firstOrNull()?.toSnapshot(DEV_BUNDLES_HOST)
-            }
-        }
-
-        if (stableResponse is APIResponse.Success) {
-            return APIResponse.Success(null)
-        }
-
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-            is APIResponse.Success -> APIResponse.Success(null)
-        }
+        )
     }
 
     suspend fun getBundleHistory(
@@ -197,72 +146,126 @@ class ExternalBundlesApi(
         }
 
         val targetLimit = limit.coerceAtLeast(1)
+        val responses = coroutineScope {
+            val stable = async {
+                getBundleHistory(STABLE_ENDPOINT, trimmedOwner, trimmedRepo, prerelease, targetLimit)
+            }
+            val dev = async {
+                getBundleHistory(DEV_ENDPOINT, trimmedOwner, trimmedRepo, prerelease, targetLimit)
+            }
+            EndpointResponses(stable.await(), dev.await())
+        }
+        val stable = responses.stable
+        val dev = responses.dev
+        return when {
+            stable is APIResponse.Success && dev is APIResponse.Success -> {
+                val history = (stable.data + dev.data)
+                    .sortedWith { left, right ->
+                        when {
+                            isNewer(left.createdAt, right.createdAt) -> -1
+                            isNewer(right.createdAt, left.createdAt) -> 1
+                            else -> 0
+                        }
+                    }
+                    .distinctBy { snapshot ->
+                        listOf(
+                            snapshot.sourceUrl.trim().lowercase(),
+                            snapshot.version.trim().lowercase(),
+                            snapshot.isPrerelease.toString()
+                        ).joinToString("|")
+                    }
+                    .take(targetLimit)
+                APIResponse.Success(history)
+            }
+            stable is APIResponse.Success -> stable
+            dev is APIResponse.Success -> dev
+            dev is APIResponse.Error -> APIResponse.Error(dev.error)
+            dev is APIResponse.Failure -> APIResponse.Failure(dev.error)
+            else -> APIResponse.Success(emptyList())
+        }
+    }
+
+    private suspend fun getBundleHistory(
+        endpoint: Endpoint,
+        owner: String,
+        repo: String,
+        prerelease: Boolean?,
+        limit: Int
+    ): APIResponse<List<ExternalBundleSnapshot>> {
         val history = mutableListOf<ExternalBundleSnapshot>()
         var offset = 0
 
-        while (history.size < targetLimit) {
-            val pageLimit = minOf(DEFAULT_PAGE_SIZE, targetLimit - history.size)
+        while (history.size < limit) {
+            val pageLimit = minOf(DEFAULT_PAGE_SIZE, limit - history.size)
             val variables = buildBundleHistoryVariables(
-                owner = trimmedOwner,
-                repo = trimmedRepo,
+                owner = owner,
+                repo = repo,
                 limit = pageLimit,
                 offset = offset,
                 prerelease = prerelease
             )
-            val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLES_QUERY, variables)
-            if (stableResponse is APIResponse.Success) {
-                val batch = stableResponse.data.bundle.map { it.toSnapshot(STABLE_BUNDLES_HOST) }
-                if (batch.isNotEmpty()) {
+            when (val response = graphqlWithDeadline<BundlesQueryData>(endpoint.graphqlUrl, BUNDLES_QUERY, variables)) {
+                is APIResponse.Success -> {
+                    val batch = response.data.bundle.map { it.toSnapshot(endpoint.host) }
                     history += batch
                     if (batch.size < pageLimit) break
                     offset += batch.size
-                    continue
                 }
-                if (history.isNotEmpty()) break
-            }
-
-            val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLES_QUERY, variables)
-            if (devResponse is APIResponse.Success) {
-                val batch = devResponse.data.bundle.map { it.toSnapshot(DEV_BUNDLES_HOST) }
-                history += batch
-                if (batch.size < pageLimit) break
-                offset += batch.size
-                continue
-            }
-
-            return when (devResponse) {
-                is APIResponse.Error -> APIResponse.Error(devResponse.error)
-                is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
-                is APIResponse.Success -> APIResponse.Success(history)
+                is APIResponse.Error -> return APIResponse.Error(response.error)
+                is APIResponse.Failure -> return APIResponse.Failure(response.error)
             }
         }
 
-        return APIResponse.Success(history.take(targetLimit))
+        return APIResponse.Success(history.take(limit))
     }
 
-    suspend fun getBundlePatches(bundleId: Int): APIResponse<List<ExternalBundlePatch>> {
+    suspend fun getBundlePatches(bundle: ExternalBundleSnapshot): APIResponse<List<ExternalBundlePatch>> {
         val variables = buildJsonObject {
-            put("id", JsonPrimitive(bundleId))
+            put("id", JsonPrimitive(bundle.bundleId))
         }
-        val stableResponse = graphql<BundlesQueryData>(STABLE_GRAPHQL_URL, BUNDLE_PATCHES_QUERY, variables)
-        if (stableResponse is APIResponse.Success) {
-            return stableResponse.transform { data ->
-                val bundle = data.bundle.firstOrNull()
-                bundle?.patches?.map { it.toPatch() }.orEmpty()
+        val preferredEndpoint = endpointForHost(bundle.apiHost) ?: STABLE_ENDPOINT
+        val fallbackEndpoint = if (preferredEndpoint == STABLE_ENDPOINT) DEV_ENDPOINT else STABLE_ENDPOINT
+        val preferredResponse = graphqlWithDeadline<BundlesQueryData>(
+            preferredEndpoint.graphqlUrl,
+            BUNDLE_PATCHES_QUERY,
+            variables
+        )
+        val preferredPatches = (preferredResponse as? APIResponse.Success)
+            ?.data
+            ?.bundle
+            ?.firstOrNull()
+            ?.patches
+            ?.map { it.toPatch() }
+        if (preferredPatches != null && (preferredPatches.isNotEmpty() || bundle.patchCount <= 0)) {
+            return APIResponse.Success(preferredPatches)
+        }
+
+        val fallbackVariables = buildBundleIdentityVariables(bundle)
+            ?: return preferredPatches?.let { APIResponse.Success(it) }
+                ?: preferredResponse.transform { data ->
+                    data.bundle.firstOrNull()?.patches?.map { it.toPatch() }.orEmpty()
+                }
+        val fallbackResponse = graphqlWithDeadline<BundlesQueryData>(
+            fallbackEndpoint.graphqlUrl,
+            BUNDLE_PATCHES_BY_IDENTITY_QUERY,
+            fallbackVariables
+        )
+        if (fallbackResponse is APIResponse.Success) {
+            val fallbackPatches = fallbackResponse.data.bundle
+                .firstOrNull()
+                ?.patches
+                ?.map { it.toPatch() }
+                .orEmpty()
+            if (fallbackPatches.isNotEmpty() || preferredPatches == null) {
+                return APIResponse.Success(fallbackPatches)
             }
         }
 
-        val devResponse = graphql<BundlesQueryData>(DEV_GRAPHQL_URL, BUNDLE_PATCHES_QUERY, variables)
-        if (devResponse is APIResponse.Success) {
-            return devResponse.transform { data ->
-                val bundle = data.bundle.firstOrNull()
-                bundle?.patches?.map { it.toPatch() }.orEmpty()
-            }
-        }
+        preferredPatches?.let { return APIResponse.Success(it) }
 
-        return when (devResponse) {
-            is APIResponse.Error -> APIResponse.Error(devResponse.error)
-            is APIResponse.Failure -> APIResponse.Failure(devResponse.error)
+        return when (fallbackResponse) {
+            is APIResponse.Error -> APIResponse.Error(fallbackResponse.error)
+            is APIResponse.Failure -> APIResponse.Failure(fallbackResponse.error)
             is APIResponse.Success -> APIResponse.Success(emptyList())
         }
     }
@@ -296,6 +299,16 @@ class ExternalBundlesApi(
         }
     }
 
+    private suspend inline fun <reified T> graphqlWithDeadline(
+        endpointUrl: String,
+        query: String,
+        variables: JsonObject? = null,
+    ): APIResponse<T> = withTimeoutOrNull(ExternalBundlesEndpoints.HOST_QUERY_TIMEOUT_MS) {
+        graphql<T>(endpointUrl, query, variables)
+    } ?: APIResponse.Failure(
+        APIFailure(IOException("Timed out querying $endpointUrl"), null)
+    )
+
     private fun BundleNode.toSnapshot(bundlesHost: String): ExternalBundleSnapshot {
         val metadata = source?.sourceMetadata
         val bundleTypeValue = bundleType?.trim().orEmpty()
@@ -310,6 +323,7 @@ class ExternalBundlesApi(
         val normalizedSignatureUrl = normalizeExternalBundlesUrl(signatureDownloadUrl, bundlesHost)
 
         return ExternalBundleSnapshot(
+            apiHost = bundlesHost,
             ownerName = metadata?.ownerName.orEmpty(),
             ownerAvatarUrl = metadata?.ownerAvatarUrl,
             repoName = metadata?.repoName.orEmpty(),
@@ -441,13 +455,148 @@ class ExternalBundlesApi(
         put("offset", JsonPrimitive(offset))
     }
 
+    private fun BundlesQueryData.toDiscoveryPage(endpoint: Endpoint) = ExternalBundlesPage(
+        bundles = bundle.map { it.toSnapshot(endpoint.host) },
+        apiHost = endpoint.host,
+        refreshJob = refreshJobs.firstOrNull()
+    )
+
+    private fun buildBundleIdentityVariables(bundle: ExternalBundleSnapshot): JsonObject? {
+        val sourceUrl = bundle.sourceUrl.trim().removeSuffix("/")
+        val version = bundle.version.trim()
+        if (sourceUrl.isBlank() || version.isBlank()) return null
+        return buildJsonObject {
+            put("sourceUrls", buildJsonArray {
+                add(JsonPrimitive(sourceUrl))
+                add(JsonPrimitive("$sourceUrl/"))
+            })
+            put("version", JsonPrimitive(version))
+            put("prerelease", JsonPrimitive(bundle.isPrerelease))
+        }
+    }
+
+    private data class Endpoint(
+        val host: String,
+        val graphqlUrl: String
+    )
+
+    private data class EndpointResponses<T>(
+        val stable: APIResponse<T>,
+        val dev: APIResponse<T>
+    )
+
+    private data class EndpointSuccess<T>(
+        val endpoint: Endpoint,
+        val data: T
+    )
+
+    private suspend inline fun <reified T> queryBoth(
+        query: String,
+        variables: JsonObject?
+    ): EndpointResponses<T> = coroutineScope {
+        val stable = async { graphqlWithDeadline<T>(STABLE_ENDPOINT.graphqlUrl, query, variables) }
+        val dev = async { graphqlWithDeadline<T>(DEV_ENDPOINT.graphqlUrl, query, variables) }
+        EndpointResponses(stable.await(), dev.await())
+    }
+
+    private fun <T, R> selectFreshestResponse(
+        responses: EndpointResponses<T>,
+        timestamp: (T) -> String?,
+        transform: (T, Endpoint) -> R,
+        preferDev: ((dev: T, stable: T) -> Boolean)? = null
+    ): APIResponse<R> {
+        val stable = responses.stable
+        val dev = responses.dev
+        val selected = when {
+            stable is APIResponse.Success && dev is APIResponse.Success -> {
+                val devIsFresher = preferDev?.invoke(dev.data, stable.data)
+                    ?: isNewer(timestamp(dev.data), timestamp(stable.data))
+                if (devIsFresher) {
+                    EndpointSuccess(DEV_ENDPOINT, dev.data)
+                } else {
+                    EndpointSuccess(STABLE_ENDPOINT, stable.data)
+                }
+            }
+            stable is APIResponse.Success -> EndpointSuccess(STABLE_ENDPOINT, stable.data)
+            dev is APIResponse.Success -> EndpointSuccess(DEV_ENDPOINT, dev.data)
+            else -> return when (dev) {
+                is APIResponse.Error -> APIResponse.Error(dev.error)
+                is APIResponse.Failure -> APIResponse.Failure(dev.error)
+                is APIResponse.Success -> APIResponse.Success(transform(dev.data, DEV_ENDPOINT))
+            }
+        }
+        return APIResponse.Success(transform(selected.data, selected.endpoint))
+    }
+
+    private fun isDevDiscoveryResponseFresher(
+        dev: BundlesQueryData,
+        stable: BundlesQueryData
+    ): Boolean {
+        val devBundle = dev.bundle.firstOrNull()
+        val stableBundle = stable.bundle.firstOrNull()
+        when {
+            devBundle != null && stableBundle == null -> return true
+            devBundle == null -> return false
+            isNewer(devBundle.createdAt, stableBundle?.createdAt) -> return true
+            isNewer(stableBundle?.createdAt, devBundle.createdAt) -> return false
+        }
+
+        val devRefresh = dev.refreshJobs.firstOrNull()
+        val stableRefresh = stable.refreshJobs.firstOrNull()
+        return isNewer(
+            newestTimestamp(devRefresh?.completedAt, devRefresh?.startedAt),
+            newestTimestamp(stableRefresh?.completedAt, stableRefresh?.startedAt)
+        )
+    }
+
+    private fun endpointForHost(host: String): Endpoint? = when {
+        host.equals(STABLE_ENDPOINT.host, ignoreCase = true) -> STABLE_ENDPOINT
+        host.equals(DEV_ENDPOINT.host, ignoreCase = true) -> DEV_ENDPOINT
+        else -> null
+    }
+
+    private fun isNewer(candidate: String?, baseline: String?): Boolean {
+        val candidateValue = candidate?.trim().takeIf { !it.isNullOrBlank() } ?: return false
+        val baselineValue = baseline?.trim().takeIf { !it.isNullOrBlank() } ?: return true
+        val candidateInstant = parseTimestamp(candidateValue)
+        val baselineInstant = parseTimestamp(baselineValue)
+        return if (candidateInstant != null && baselineInstant != null) {
+            candidateInstant > baselineInstant
+        } else {
+            candidateValue > baselineValue
+        }
+    }
+
+    private fun newestTimestamp(vararg values: String?): String? =
+        values.mapNotNull { it?.trim()?.takeIf(String::isNotBlank) }
+            .reduceOrNull { newest, candidate ->
+                if (isNewer(candidate, newest)) candidate else newest
+            }
+
+    private fun parseTimestamp(raw: String): Instant? =
+        runCatching { Instant.parse(raw) }.getOrNull()
+            ?: runCatching { LocalDateTime.parse(raw).toInstant(TimeZone.UTC) }.getOrNull()
+
     companion object {
-        private const val DEV_GRAPHQL_URL = "https://revanced-external-bundles-dev.brosssh.com/hasura/v1/graphql"
-        private const val STABLE_GRAPHQL_URL = "https://revanced-external-bundles.brosssh.com/hasura/v1/graphql"
-        private const val DEV_BUNDLES_HOST = "revanced-external-bundles-dev.brosssh.com"
-        private const val STABLE_BUNDLES_HOST = "revanced-external-bundles.brosssh.com"
+        private val STABLE_ENDPOINT = Endpoint(
+            host = ExternalBundlesEndpoints.STABLE_HOST,
+            graphqlUrl = "https://${ExternalBundlesEndpoints.STABLE_HOST}/hasura/v1/graphql"
+        )
+        private val DEV_ENDPOINT = Endpoint(
+            host = ExternalBundlesEndpoints.DEV_HOST,
+            graphqlUrl = "https://${ExternalBundlesEndpoints.DEV_HOST}/hasura/v1/graphql"
+        )
         private const val BUNDLES_QUERY = """
             query BundleDiscovery(${"$"}where: bundle_bool_exp, ${"$"}limit: Int, ${"$"}offset: Int) {
+              refresh_jobs(
+                where: { status: { _eq: "COMPLETED" } }
+                order_by: { started_at: desc }
+                limit: 1
+              ) {
+                started_at
+                completed_at
+                status
+              }
               bundle(
                 where: ${"$"}where
                 order_by: { created_at: desc }
@@ -499,6 +648,35 @@ class ExternalBundlesApi(
               }
             }
         """
+        private const val BUNDLE_PATCHES_BY_IDENTITY_QUERY = """
+            query BundlePatchesByIdentity(
+              ${"$"}sourceUrls: [String!]!
+              ${"$"}version: String!
+              ${"$"}prerelease: Boolean!
+            ) {
+              bundle(
+                where: {
+                  source: { url: { _in: ${"$"}sourceUrls } }
+                  version: { _eq: ${"$"}version }
+                  is_prerelease: { _eq: ${"$"}prerelease }
+                }
+                order_by: { created_at: desc }
+                limit: 1
+              ) {
+                id
+                patches {
+                  name
+                  description
+                  patch_packages {
+                    package {
+                      name
+                      version
+                    }
+                  }
+                }
+              }
+            }
+        """
         private const val BUNDLE_BY_ID_QUERY = """
             query BundleById(${"$"}id: Int!) {
               bundle(where: { id: { _eq: ${"$"}id } }) {
@@ -527,14 +705,6 @@ class ExternalBundlesApi(
                     count
                   }
                 }
-              }
-            }
-        """
-        private const val REFRESH_JOBS_QUERY = """
-            query RefreshJobs {
-              refresh_jobs(order_by: { started_at: desc }, limit: 1) {
-                started_at
-                status
               }
             }
         """

--- a/app/src/main/java/app/urv/manager/network/api/ExternalBundlesEndpoints.kt
+++ b/app/src/main/java/app/urv/manager/network/api/ExternalBundlesEndpoints.kt
@@ -38,6 +38,18 @@ object ExternalBundlesEndpoints {
         else -> null
     }
 
+    fun preferredHost(stableVersion: String?, devVersion: String?): String {
+        val stable = ApiVersion.parse(stableVersion)
+        val dev = ApiVersion.parse(devVersion)
+        return when {
+            stable == null && dev == null -> DEV_HOST
+            stable == null -> DEV_HOST
+            dev == null -> STABLE_HOST
+            dev > stable -> DEV_HOST
+            else -> STABLE_HOST
+        }
+    }
+
     fun siteUrl(host: String?): String {
         val normalizedHost = host
             ?.trim()
@@ -52,4 +64,56 @@ object ExternalBundlesEndpoints {
             path.startsWith("/api/v2/bundle/") ||
             path.equals(V3_BUNDLE_PATH, ignoreCase = true) ||
             path.startsWith("/bundles/id")
+
+    private data class ApiVersion(
+        val core: List<Long>,
+        val prerelease: List<String>
+    ) : Comparable<ApiVersion> {
+        override fun compareTo(other: ApiVersion): Int {
+            val coreSize = maxOf(core.size, other.core.size)
+            for (index in 0 until coreSize) {
+                val comparison = core.getOrElse(index) { 0 }
+                    .compareTo(other.core.getOrElse(index) { 0 })
+                if (comparison != 0) return comparison
+            }
+
+            if (prerelease.isEmpty() && other.prerelease.isEmpty()) return 0
+            if (prerelease.isEmpty()) return 1
+            if (other.prerelease.isEmpty()) return -1
+
+            val prereleaseSize = maxOf(prerelease.size, other.prerelease.size)
+            for (index in 0 until prereleaseSize) {
+                val left = prerelease.getOrNull(index) ?: return -1
+                val right = other.prerelease.getOrNull(index) ?: return 1
+                val leftNumber = left.toLongOrNull()
+                val rightNumber = right.toLongOrNull()
+                val comparison = when {
+                    leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+                    leftNumber != null -> -1
+                    rightNumber != null -> 1
+                    else -> left.compareTo(right, ignoreCase = true)
+                }
+                if (comparison != 0) return comparison
+            }
+            return 0
+        }
+
+        companion object {
+            private val pattern = Regex(
+                "^[vV]?(\\d+(?:\\.\\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\\+[0-9A-Za-z.-]+)?$"
+            )
+
+            fun parse(value: String?): ApiVersion? {
+                val match = value?.trim()?.let(pattern::matchEntire) ?: return null
+                val core = match.groupValues[1]
+                    .split('.')
+                    .map { it.toLongOrNull() ?: return null }
+                val prerelease = match.groupValues[2]
+                    .takeIf(String::isNotBlank)
+                    ?.split('.')
+                    .orEmpty()
+                return ApiVersion(core, prerelease)
+            }
+        }
+    }
 }

--- a/app/src/main/java/app/urv/manager/network/api/ExternalBundlesEndpoints.kt
+++ b/app/src/main/java/app/urv/manager/network/api/ExternalBundlesEndpoints.kt
@@ -1,0 +1,55 @@
+package app.urv.manager.network.api
+
+import java.net.URLEncoder
+import java.util.Locale
+
+object ExternalBundlesEndpoints {
+    const val STABLE_HOST = "revanced-external-bundles.brosssh.com"
+    const val DEV_HOST = "revanced-external-bundles-dev.brosssh.com"
+    const val V3_BUNDLE_PATH = "/api/v3/bundle"
+    const val HOST_QUERY_TIMEOUT_MS = 8_000L
+
+    fun latestBundleUrl(
+        host: String,
+        sourceUrl: String,
+        prerelease: Boolean?
+    ): String? {
+        val normalizedHost = host.trim().lowercase(Locale.US)
+        if (normalizedHost != STABLE_HOST && normalizedHost != DEV_HOST) return null
+        val normalizedSourceUrl = sourceUrl.trim().removeSuffix("/")
+        if (normalizedSourceUrl.isBlank()) return null
+        val channel = when (prerelease) {
+            null -> "any"
+            true -> "prerelease"
+            false -> "stable"
+        }
+        val encodedSourceUrl = URLEncoder.encode(normalizedSourceUrl, Charsets.UTF_8.name())
+        return "https://$normalizedHost$V3_BUNDLE_PATH" +
+            "?source_url=$encodedSourceUrl&version=latest&channel=$channel"
+    }
+
+    fun isExternalBundlesHost(host: String): Boolean =
+        host.equals(STABLE_HOST, ignoreCase = true) ||
+            host.equals(DEV_HOST, ignoreCase = true)
+
+    fun alternateHost(host: String?): String? = when (host?.trim()?.lowercase(Locale.US)) {
+        STABLE_HOST -> DEV_HOST
+        DEV_HOST -> STABLE_HOST
+        else -> null
+    }
+
+    fun siteUrl(host: String?): String {
+        val normalizedHost = host
+            ?.trim()
+            ?.lowercase(Locale.US)
+            ?.takeIf(::isExternalBundlesHost)
+            ?: STABLE_HOST
+        return "https://$normalizedHost/"
+    }
+
+    fun isBundleApiPath(path: String): Boolean =
+        path.startsWith("/api/v1/bundle/") ||
+            path.startsWith("/api/v2/bundle/") ||
+            path.equals(V3_BUNDLE_PATH, ignoreCase = true) ||
+            path.startsWith("/bundles/id")
+}

--- a/app/src/main/java/app/urv/manager/network/dto/ExternalBundleSnapshot.kt
+++ b/app/src/main/java/app/urv/manager/network/dto/ExternalBundleSnapshot.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ExternalBundleSnapshot(
+    val apiHost: String = "",
     val ownerName: String = "",
     val ownerAvatarUrl: String? = null,
     val repoName: String = "",

--- a/app/src/main/java/app/urv/manager/network/dto/ExternalBundlesGraphql.kt
+++ b/app/src/main/java/app/urv/manager/network/dto/ExternalBundlesGraphql.kt
@@ -24,10 +24,6 @@ data class GraphqlError(
 @Serializable
 data class BundlesQueryData(
     val bundle: List<BundleNode> = emptyList(),
-)
-
-@Serializable
-data class RefreshJobsQueryData(
     @SerialName("refresh_jobs")
     val refreshJobs: List<RefreshJobNode> = emptyList(),
 )
@@ -57,6 +53,8 @@ data class BundleNode(
 data class RefreshJobNode(
     @SerialName("started_at")
     val startedAt: String? = null,
+    @SerialName("completed_at")
+    val completedAt: String? = null,
     val status: String? = null,
 )
 

--- a/app/src/main/java/app/urv/manager/ui/model/navigation/Nav.kt
+++ b/app/src/main/java/app/urv/manager/ui/model/navigation/Nav.kt
@@ -37,7 +37,16 @@ data object BatchPatchesSelector :
 object PatchBundleDiscovery
 
 @Serializable
-data class PatchBundleDiscoveryPatches(val bundleId: Int)
+data class PatchBundleDiscoveryPatches(
+    val bundleId: Int,
+    val apiHost: String = "",
+    val sourceUrl: String = "",
+    val version: String = "",
+    val isPrerelease: Boolean = false,
+    val patchCount: Int = 0,
+    val ownerName: String = "",
+    val repoName: String = ""
+)
 
 @Serializable
 data object MergeSplitApk

--- a/app/src/main/java/app/urv/manager/ui/screen/PatchBundleDiscoveryPatchesScreen.kt
+++ b/app/src/main/java/app/urv/manager/ui/screen/PatchBundleDiscoveryPatchesScreen.kt
@@ -48,6 +48,7 @@ import app.urv.manager.domain.bundles.PatchBundleSource.Extensions.asRemoteOrNul
 import app.urv.manager.domain.manager.PreferencesManager
 import app.urv.manager.domain.repository.PatchBundleRepository
 import app.urv.manager.network.dto.ExternalBundlePatch
+import app.urv.manager.network.dto.ExternalBundleSnapshot
 import app.urv.manager.patcher.patch.PatchInfo
 import app.urv.manager.ui.component.AppTopBar
 import app.urv.manager.ui.component.LazyColumnWithScrollbar
@@ -66,6 +67,13 @@ import org.koin.compose.koinInject
 @Composable
 fun PatchBundleDiscoveryPatchesScreen(
     bundleId: Int,
+    apiHost: String,
+    sourceUrl: String,
+    version: String,
+    isPrerelease: Boolean,
+    patchCount: Int,
+    ownerName: String,
+    repoName: String,
     onBackClick: () -> Unit,
     viewModel: BundleDiscoveryViewModel = koinViewModel(),
 ) {
@@ -79,15 +87,39 @@ fun PatchBundleDiscoveryPatchesScreen(
     val bundles = viewModel.bundles
     val isLoading = viewModel.isLoading
     val errorMessage = viewModel.errorMessage
-    val bundle = remember(bundles, bundleId) {
-        bundles?.firstOrNull { it.bundleId == bundleId }
+    val routedBundle = remember(
+        bundleId,
+        apiHost,
+        sourceUrl,
+        version,
+        isPrerelease,
+        patchCount,
+        ownerName,
+        repoName
+    ) {
+        ExternalBundleSnapshot(
+            apiHost = apiHost,
+            bundleId = bundleId,
+            sourceUrl = sourceUrl,
+            version = version,
+            isPrerelease = isPrerelease,
+            patchCount = patchCount,
+            ownerName = ownerName,
+            repoName = repoName
+        )
     }
-    val patches = viewModel.getPatches(bundleId)
-    val patchesLoading = viewModel.isPatchesLoading(bundleId)
-    val patchesError = viewModel.getPatchesError(bundleId)
+    val bundle = remember(bundles, routedBundle) {
+        bundles?.firstOrNull {
+            it.bundleId == routedBundle.bundleId &&
+                it.apiHost.equals(routedBundle.apiHost, ignoreCase = true)
+        } ?: routedBundle
+    }
+    val patches = viewModel.getPatches(bundle)
+    val patchesLoading = viewModel.isPatchesLoading(bundle)
+    val patchesError = viewModel.getPatchesError(bundle)
 
     val importedUid = remember(bundle, sources) {
-        val endpoints = bundle?.let { viewModel.bundleEndpoints(it) }.orEmpty()
+        val endpoints = viewModel.bundleEndpoints(bundle)
         sources.firstOrNull { src ->
             src.asRemoteOrNull?.endpoint in endpoints
         }?.uid
@@ -111,9 +143,14 @@ fun PatchBundleDiscoveryPatchesScreen(
         }
     }
 
-    LaunchedEffect(bundleId, useLocalPatches) {
-        if (!useLocalPatches) {
-            viewModel.loadPatches(bundleId)
+    LaunchedEffect(bundle, useLocalPatches, patches, patchesLoading, patchesError) {
+        if (
+            !useLocalPatches &&
+            patches == null &&
+            !patchesLoading &&
+            patchesError == null
+        ) {
+            viewModel.loadPatches(bundle)
         }
     }
 

--- a/app/src/main/java/app/urv/manager/ui/screen/PatchBundleDiscoveryScreen.kt
+++ b/app/src/main/java/app/urv/manager/ui/screen/PatchBundleDiscoveryScreen.kt
@@ -121,7 +121,7 @@ import java.util.Locale
 @Composable
 fun PatchBundleDiscoveryScreen(
     onBackClick: () -> Unit,
-    onViewPatches: (Int) -> Unit,
+    onViewPatches: (ExternalBundleSnapshot) -> Unit,
     viewModel: BundleDiscoveryViewModel = koinViewModel(),
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
@@ -614,7 +614,7 @@ fun PatchBundleDiscoveryScreen(
                         }
                     }
                     IconButton(
-                        onClick = { context.openUrl("https://revanced-external-bundles.brosssh.com/") }
+                        onClick = { context.openUrl(viewModel.discoverySiteUrl()) }
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Link,
@@ -909,9 +909,7 @@ fun PatchBundleDiscoveryScreen(
                                     preferLatestAcrossChannels = useLatest
                                 )
                             },
-                            onViewPatches = { bundle ->
-                                onViewPatches(bundle.bundleId)
-                            },
+                            onViewPatches = onViewPatches,
                             onMenuRequest = { activeBundleMenu = it },
                             exportProgressFor = viewModel::getExportProgress,
                             importProgressFor = { bundle, isImported ->

--- a/app/src/main/java/app/urv/manager/ui/viewmodel/BundleDiscoveryViewModel.kt
+++ b/app/src/main/java/app/urv/manager/ui/viewmodel/BundleDiscoveryViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import app.universal.revanced.manager.R
 import app.urv.manager.domain.repository.PatchBundleRepository
 import app.urv.manager.network.api.ExternalBundlesApi
+import app.urv.manager.network.api.ExternalBundlesEndpoints
 import app.urv.manager.network.dto.ExternalBundleSnapshot
 import app.urv.manager.network.dto.ExternalBundlePatch
 import app.urv.manager.network.service.HttpService
@@ -22,8 +23,6 @@ import io.ktor.client.request.url
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -57,17 +56,20 @@ class BundleDiscoveryViewModel(
     var bundleSearchQuery: String by mutableStateOf("")
     var packageSearchQuery: String by mutableStateOf("")
 
-    private val patchesByBundle = mutableStateMapOf<Int, List<ExternalBundlePatch>>()
-    private val patchesLoading = mutableStateMapOf<Int, Boolean>()
-    private val patchesError = mutableStateMapOf<Int, String?>()
+    private val patchesByBundle = mutableStateMapOf<BundleInstanceKey, List<ExternalBundlePatch>>()
+    private val patchesLoading = mutableStateMapOf<BundleInstanceKey, Boolean>()
+    private val patchesError = mutableStateMapOf<BundleInstanceKey, String?>()
     private val bundleCache = mutableMapOf<String, BundleCacheEntry>()
     private val bundleExports = mutableStateMapOf<Int, BundleExportProgress>()
     private val cacheDir = File(app.cacheDir, "bundle_discovery").also { it.mkdirs() }
     private var refreshJob: Job? = null
     private var searchJob: Job? = null
     private var currentQueryKey: String = ""
+    private var currentApiHost: String? = null
     private var nextOffset: Int = 0
     private var refreshToken: Int = 0
+    private var bundleDatasetGeneration: Int = 0
+    private var isFirstPageRefreshInProgress: Boolean = false
     private var searchToken: Int = 0
     private var importProgressSnapshot by mutableStateOf<Map<String, PatchBundleRepository.DiscoveryImportProgress>>(emptyMap())
     private var queuedImportSnapshot by mutableStateOf<Set<String>>(emptySet())
@@ -110,60 +112,78 @@ class BundleDiscoveryViewModel(
         currentQueryKey = key
         nextOffset = 0
         canLoadMore = true
+        invalidatePatchState()
         val cached = bundleCache[key] ?: loadDiskCache(key)?.also { bundleCache[key] = it }
         if (cached != null) {
+            currentApiHost = cached.apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+                ?: cached.bundles.firstNotNullOfOrNull { bundle ->
+                    bundle.apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+                }
             bundles = applyLastRefreshed(cached.bundles)
+        } else {
+            currentApiHost = null
         }
         val token = ++refreshToken
+        isFirstPageRefreshInProgress = true
         viewModelScope.launch {
             if (token != refreshToken) return@launch
             isLoading = cached == null
             errorMessage = null
-            val (snapshot, refreshJob) = withContext(Dispatchers.IO) {
-                coroutineScope {
-                    val bundlesDeferred = async {
-                        api.getBundles(packageNameQuery, limit = PAGE_SIZE, offset = 0).getOrNull()
+            try {
+                val page = withContext(Dispatchers.IO) {
+                    api.getBundles(packageNameQuery, limit = PAGE_SIZE, offset = 0).getOrNull()
+                }
+                if (token != refreshToken) return@launch
+                val refreshJob = page?.refreshJob
+                val refreshedAt = (refreshJob?.completedAt ?: refreshJob?.startedAt)
+                    ?.trim()
+                    .takeIf { !it.isNullOrBlank() }
+                if (refreshedAt != null && refreshedAt != lastRefreshAt) {
+                    lastRefreshAt = refreshedAt
+                }
+                if (page == null) {
+                    if (cached == null) {
+                        errorMessage = app.getString(R.string.patch_bundle_discovery_error)
+                    } else if (lastRefreshAt != null) {
+                        val updatedBundles = applyLastRefreshed(cached.bundles)
+                        val entry = BundleCacheEntry(
+                            bundles = updatedBundles,
+                            fingerprint = fingerprint(updatedBundles),
+                            apiHost = cached.apiHost
+                        )
+                        bundleCache[key] = entry
+                        bundles = entry.bundles
+                        persistDiskCache(key, entry)
                     }
-                    val refreshDeferred = async {
-                        api.getLatestRefreshJob().getOrNull()
+                } else {
+                    currentApiHost = page.apiHost
+                    val resolvedSnapshot = applyLastRefreshed(page.bundles)
+                    val fingerprint = fingerprint(resolvedSnapshot)
+                    if (cached == null || cached.fingerprint != fingerprint || cached.apiHost != page.apiHost) {
+                        val entry = BundleCacheEntry(
+                            bundles = resolvedSnapshot,
+                            fingerprint = fingerprint,
+                            apiHost = page.apiHost
+                        )
+                        bundleCache[key] = entry
+                        bundles = entry.bundles
+                        persistDiskCache(key, entry)
                     }
-                    bundlesDeferred.await() to refreshDeferred.await()
+                    nextOffset = resolvedSnapshot.size
+                    canLoadMore = resolvedSnapshot.size >= PAGE_SIZE
+                    errorMessage = null
+                }
+            } finally {
+                if (token == refreshToken) {
+                    isLoading = false
+                    isFirstPageRefreshInProgress = false
                 }
             }
-            if (token != refreshToken) return@launch
-            val refreshedAt = refreshJob?.startedAt?.trim().takeIf { !it.isNullOrBlank() }
-            if (refreshedAt != null && refreshedAt != lastRefreshAt) {
-                lastRefreshAt = refreshedAt
-            }
-            val resolvedSnapshot = snapshot?.let { applyLastRefreshed(it) }
-            if (resolvedSnapshot == null) {
-                if (cached == null) {
-                    errorMessage = app.getString(R.string.patch_bundle_discovery_error)
-                } else if (lastRefreshAt != null) {
-                    val updatedBundles = applyLastRefreshed(cached.bundles)
-                    val entry = BundleCacheEntry(updatedBundles, fingerprint(updatedBundles))
-                    bundleCache[key] = entry
-                    bundles = entry.bundles
-                    persistDiskCache(key, entry)
-                }
-            } else {
-                val fingerprint = fingerprint(resolvedSnapshot)
-                if (cached == null || cached.fingerprint != fingerprint) {
-                    val entry = BundleCacheEntry(resolvedSnapshot, fingerprint)
-                    bundleCache[key] = entry
-                    bundles = entry.bundles
-                    persistDiskCache(key, entry)
-                }
-                nextOffset = resolvedSnapshot.size
-                canLoadMore = resolvedSnapshot.size >= PAGE_SIZE
-                errorMessage = null
-            }
-            isLoading = false
         }
     }
 
     fun loadMore() {
-        if (!canLoadMore || isLoadingMore) return
+        if (isFirstPageRefreshInProgress || !canLoadMore || isLoadingMore) return
         viewModelScope.launch {
             loadNextPageInternal(force = false)
         }
@@ -194,7 +214,7 @@ class BundleDiscoveryViewModel(
             try {
                 val queryLower = trimmedBundle.lowercase()
                 while (token == refreshToken) {
-                    if (isLoading || isLoadingMore) {
+                    if (isLoading || isFirstPageRefreshInProgress || isLoadingMore) {
                         delay(50)
                         continue
                     }
@@ -325,34 +345,60 @@ class BundleDiscoveryViewModel(
     fun bundleEndpoints(bundle: ExternalBundleSnapshot): Set<String> {
         val endpoints = mutableSetOf<String>()
         bundle.downloadUrl?.let { endpoints.add(it) }
-        graphqlBundleEndpoint(bundle, useDev = false, prerelease = null)?.let { endpoints.add(it) }
-        graphqlBundleEndpoint(bundle, useDev = true, prerelease = null)?.let { endpoints.add(it) }
-        graphqlBundleEndpoint(bundle, useDev = false)?.let { endpoints.add(it) }
-        graphqlBundleEndpoint(bundle, useDev = true)?.let { endpoints.add(it) }
-        legacyEndpoint(bundle.bundleId)?.let { endpoints.add(it) }
+        externalBundleEndpoint(bundle, useDev = false, prerelease = null)?.let { endpoints.add(it) }
+        externalBundleEndpoint(bundle, useDev = true, prerelease = null)?.let { endpoints.add(it) }
+        externalBundleEndpoint(bundle, useDev = false)?.let { endpoints.add(it) }
+        externalBundleEndpoint(bundle, useDev = true)?.let { endpoints.add(it) }
+        legacyV2Endpoint(bundle, useDev = false, prerelease = null)?.let { endpoints.add(it) }
+        legacyV2Endpoint(bundle, useDev = true, prerelease = null)?.let { endpoints.add(it) }
+        legacyV2Endpoint(bundle, useDev = false)?.let { endpoints.add(it) }
+        legacyV2Endpoint(bundle, useDev = true)?.let { endpoints.add(it) }
+        legacyEndpoint(bundle.bundleId, bundleApiHost(bundle)).let(endpoints::add)
         return endpoints
     }
 
-    fun remoteBundleUrl(bundle: ExternalBundleSnapshot): String? {
-        val host = bundleHostFromDownload(bundle.downloadUrl)
-            ?: bundleHostFromDownload(bundle.signatureDownloadUrl)
-            ?: STABLE_BUNDLES_HOST
-        val owner = bundle.ownerName.trim()
-        val repo = bundle.repoName.trim()
-        return if (owner.isNotBlank() && repo.isNotBlank()) {
-            val channel = if (bundle.isPrerelease) "prerelease" else "stable"
-            "https://$host/api/v2/bundle/$owner/$repo/latest?channel=$channel"
-        } else if (bundle.bundleId > 0) {
-            "https://$host/bundles/id?id=${bundle.bundleId}"
-        } else {
-            null
-        }
+    fun discoverySiteUrl(): String {
+        val host = currentApiHost
+            ?.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+            ?: bundles.orEmpty().firstNotNullOfOrNull { bundle ->
+                bundle.apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+            }
+        return ExternalBundlesEndpoints.siteUrl(host)
     }
 
-    private fun legacyEndpoint(bundleId: Int): String? =
-        "https://revanced-external-bundles.brosssh.com/bundles/id?id=$bundleId"
+    fun remoteBundleUrl(bundle: ExternalBundleSnapshot): String? {
+        return ExternalBundlesEndpoints.latestBundleUrl(
+            host = bundleApiHost(bundle),
+            sourceUrl = bundleSourceUrl(bundle),
+            prerelease = bundle.isPrerelease
+        )
+    }
 
-    private fun graphqlBundleEndpoint(
+    private fun bundleApiHost(bundle: ExternalBundleSnapshot): String {
+        val apiHost = bundle.apiHost.trim().lowercase(Locale.US)
+        return apiHost.takeIf(ExternalBundlesEndpoints::isExternalBundlesHost)
+            ?: bundleHostFromDownload(bundle.downloadUrl)
+            ?: bundleHostFromDownload(bundle.signatureDownloadUrl)
+            ?: ExternalBundlesEndpoints.STABLE_HOST
+    }
+
+    private fun legacyEndpoint(bundleId: Int, apiHost: String): String =
+        "https://$apiHost/bundles/id?id=$bundleId"
+
+    private fun externalBundleEndpoint(
+        bundle: ExternalBundleSnapshot,
+        useDev: Boolean,
+        prerelease: Boolean? = bundle.isPrerelease
+    ): String? {
+        val host = if (useDev) {
+            ExternalBundlesEndpoints.DEV_HOST
+        } else {
+            ExternalBundlesEndpoints.STABLE_HOST
+        }
+        return ExternalBundlesEndpoints.latestBundleUrl(host, bundleSourceUrl(bundle), prerelease)
+    }
+
+    private fun legacyV2Endpoint(
         bundle: ExternalBundleSnapshot,
         useDev: Boolean,
         prerelease: Boolean? = bundle.isPrerelease
@@ -360,11 +406,7 @@ class BundleDiscoveryViewModel(
         val owner = bundle.ownerName.trim()
         val repo = bundle.repoName.trim()
         if (owner.isBlank() || repo.isBlank()) return null
-        val host = if (useDev) {
-            "revanced-external-bundles-dev.brosssh.com"
-        } else {
-            "revanced-external-bundles.brosssh.com"
-        }
+        val host = if (useDev) ExternalBundlesEndpoints.DEV_HOST else ExternalBundlesEndpoints.STABLE_HOST
         val channel = when (prerelease) {
             null -> "any"
             true -> "prerelease"
@@ -373,35 +415,54 @@ class BundleDiscoveryViewModel(
         return "https://$host/api/v2/bundle/$owner/$repo/latest?channel=$channel"
     }
 
-    fun loadPatches(bundleId: Int) {
-        if (patchesByBundle.containsKey(bundleId) || patchesLoading[bundleId] == true) return
+    private fun bundleSourceUrl(bundle: ExternalBundleSnapshot): String =
+        bundle.sourceUrl.trim().takeIf { it.isNotBlank() }
+            ?: if (bundle.ownerName.isNotBlank() && bundle.repoName.isNotBlank()) {
+                "https://github.com/${bundle.ownerName.trim()}/${bundle.repoName.trim()}"
+            } else {
+                ""
+            }
+
+    fun loadPatches(bundle: ExternalBundleSnapshot) {
+        val key = patchStateKey(bundle)
+        if (patchesByBundle.containsKey(key) || patchesLoading[key] == true) return
+        val generation = bundleDatasetGeneration
         viewModelScope.launch {
-            patchesLoading[bundleId] = true
-            patchesError[bundleId] = null
+            if (generation != bundleDatasetGeneration) return@launch
+            patchesLoading[key] = true
+            patchesError[key] = null
             try {
                 val patches = withContext(Dispatchers.IO) {
-                    api.getBundlePatches(bundleId).getOrNull()
+                    api.getBundlePatches(bundle).getOrNull()
                 }
+                if (generation != bundleDatasetGeneration) return@launch
                 if (patches == null) {
-                    patchesError[bundleId] = app.getString(R.string.patch_bundle_discovery_error)
+                    patchesError[key] = app.getString(R.string.patch_bundle_discovery_error)
                 } else {
-                    patchesByBundle[bundleId] = patches
+                    patchesByBundle[key] = patches
                 }
             } catch (cancel: CancellationException) {
                 throw cancel
             } catch (error: Throwable) {
-                patchesError[bundleId] = app.getString(R.string.patch_bundle_discovery_error)
+                if (generation == bundleDatasetGeneration) {
+                    patchesError[key] = app.getString(R.string.patch_bundle_discovery_error)
+                }
             } finally {
-                patchesLoading[bundleId] = false
+                if (generation == bundleDatasetGeneration) {
+                    patchesLoading[key] = false
+                }
             }
         }
     }
 
-    fun getPatches(bundleId: Int): List<ExternalBundlePatch>? = patchesByBundle[bundleId]
+    fun getPatches(bundle: ExternalBundleSnapshot): List<ExternalBundlePatch>? =
+        patchesByBundle[patchStateKey(bundle)]
 
-    fun isPatchesLoading(bundleId: Int): Boolean = patchesLoading[bundleId] == true
+    fun isPatchesLoading(bundle: ExternalBundleSnapshot): Boolean =
+        patchesLoading[patchStateKey(bundle)] == true
 
-    fun getPatchesError(bundleId: Int): String? = patchesError[bundleId]
+    fun getPatchesError(bundle: ExternalBundleSnapshot): String? =
+        patchesError[patchStateKey(bundle)]
 
     fun getExportProgress(bundleId: Int): BundleExportProgress? = bundleExports[bundleId]
 
@@ -447,30 +508,86 @@ class BundleDiscoveryViewModel(
     }
 
     private suspend fun loadNextPageInternal(force: Boolean): Boolean {
-        if ((!canLoadMore && !force) || isLoadingMore) return false
+        if (isFirstPageRefreshInProgress || (!canLoadMore && !force) || isLoadingMore) return false
         val key = currentQueryKey
         val query = key.takeIf { it.isNotBlank() }
+        val requestedHost = currentApiHost
+        val requestedOffset = nextOffset
+        val requestedRefreshToken = refreshToken
         isLoadingMore = true
         return try {
-            val snapshot = withContext(Dispatchers.IO) {
-                api.getBundles(query, limit = PAGE_SIZE, offset = nextOffset).getOrNull()
+            val (page, replaceCurrentPage) = withContext(Dispatchers.IO) {
+                val requestedPage = api.getBundles(
+                    packageNameQuery = query,
+                    limit = PAGE_SIZE,
+                    offset = requestedOffset,
+                    apiHost = requestedHost
+                ).getOrNull()
+                if (requestedPage != null || requestedHost == null) {
+                    requestedPage to false
+                } else {
+                    val alternateHost = ExternalBundlesEndpoints.alternateHost(requestedHost)
+                    val fallbackPage = alternateHost?.let { host ->
+                        api.getBundles(
+                            packageNameQuery = query,
+                            limit = PAGE_SIZE,
+                            offset = 0,
+                            apiHost = host
+                        ).getOrNull()
+                    }
+                    fallbackPage to (fallbackPage != null)
+                }
             }
-            val resolvedSnapshot = snapshot?.let { applyLastRefreshed(it) }
-            if (!resolvedSnapshot.isNullOrEmpty()) {
-                val current = bundles.orEmpty()
-                val updated = current + resolvedSnapshot
+            if (
+                key != currentQueryKey ||
+                requestedOffset != nextOffset ||
+                requestedHost != currentApiHost ||
+                requestedRefreshToken != refreshToken
+            ) {
+                return false
+            }
+            if (page != null) {
+                if (replaceCurrentPage) {
+                    invalidatePatchState()
+                }
+                val refreshedAt = (page.refreshJob?.completedAt ?: page.refreshJob?.startedAt)
+                    ?.trim()
+                    .takeIf { !it.isNullOrBlank() }
+                if (refreshedAt != null) {
+                    lastRefreshAt = refreshedAt
+                }
+                val resolvedSnapshot = applyLastRefreshed(page.bundles)
+                val selectedHost = page.apiHost
+                currentApiHost = selectedHost
+                val updated = if (replaceCurrentPage) {
+                    resolvedSnapshot
+                } else {
+                    bundles.orEmpty() + resolvedSnapshot
+                }
                 val cached = bundleCache[key]
                 val entry = if (cached != null) {
-                    cached.copy(bundles = updated)
+                    cached.copy(
+                        bundles = updated,
+                        fingerprint = fingerprint(updated),
+                        apiHost = selectedHost
+                    )
                 } else {
-                    BundleCacheEntry(updated, fingerprint(updated))
+                    BundleCacheEntry(
+                        bundles = updated,
+                        fingerprint = fingerprint(updated),
+                        apiHost = selectedHost
+                    )
                 }
                 bundleCache[key] = entry
                 bundles = entry.bundles
                 persistDiskCache(key, entry)
-                nextOffset += resolvedSnapshot.size
+                nextOffset = if (replaceCurrentPage) {
+                    resolvedSnapshot.size
+                } else {
+                    requestedOffset + resolvedSnapshot.size
+                }
                 canLoadMore = resolvedSnapshot.size >= PAGE_SIZE
-                true
+                resolvedSnapshot.isNotEmpty()
             } else {
                 canLoadMore = false
                 false
@@ -529,6 +646,7 @@ class BundleDiscoveryViewModel(
     private fun fingerprint(bundles: List<ExternalBundleSnapshot>): String =
         bundles.joinToString(separator = "|") { bundle ->
             listOf(
+                bundle.apiHost,
                 bundle.bundleId,
                 bundle.version,
                 bundle.downloadUrl,
@@ -560,10 +678,22 @@ class BundleDiscoveryViewModel(
         if (trimmed.isEmpty()) return null
         val host = runCatching { URI(trimmed).host?.lowercase() }.getOrNull() ?: return null
         return when {
-            host == DEV_BUNDLES_HOST -> DEV_BUNDLES_HOST
-            host == STABLE_BUNDLES_HOST -> STABLE_BUNDLES_HOST
+            host == ExternalBundlesEndpoints.DEV_HOST -> ExternalBundlesEndpoints.DEV_HOST
+            host == ExternalBundlesEndpoints.STABLE_HOST -> ExternalBundlesEndpoints.STABLE_HOST
             else -> null
         }
+    }
+
+    private fun patchStateKey(bundle: ExternalBundleSnapshot) = BundleInstanceKey(
+        apiHost = bundle.apiHost.trim().lowercase(Locale.US),
+        bundleId = bundle.bundleId
+    )
+
+    private fun invalidatePatchState() {
+        bundleDatasetGeneration++
+        patchesByBundle.clear()
+        patchesLoading.clear()
+        patchesError.clear()
     }
 
     suspend fun fetchLatestBundle(
@@ -577,7 +707,8 @@ class BundleDiscoveryViewModel(
     @Serializable
     private data class BundleCacheEntry(
         val bundles: List<ExternalBundleSnapshot>,
-        val fingerprint: String
+        val fingerprint: String,
+        val apiHost: String = ""
     )
 
     data class BundleExportProgress(val bytesRead: Long, val bytesTotal: Long?)
@@ -585,6 +716,11 @@ class BundleDiscoveryViewModel(
     private data class SearchGroup(
         val release: ExternalBundleSnapshot?,
         val prerelease: ExternalBundleSnapshot?
+    )
+
+    private data class BundleInstanceKey(
+        val apiHost: String,
+        val bundleId: Int
     )
 
     private fun cacheFileForKey(key: String): File {
@@ -611,8 +747,6 @@ class BundleDiscoveryViewModel(
     }
 
     private companion object {
-        const val STABLE_BUNDLES_HOST = "revanced-external-bundles.brosssh.com"
-        const val DEV_BUNDLES_HOST = "revanced-external-bundles-dev.brosssh.com"
         const val PAGE_SIZE = 30
     }
 }

--- a/app/src/test/java/app/urv/manager/network/api/ExternalBundlesEndpointsTest.kt
+++ b/app/src/test/java/app/urv/manager/network/api/ExternalBundlesEndpointsTest.kt
@@ -1,0 +1,55 @@
+package app.urv.manager.network.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ExternalBundlesEndpointsTest {
+    @Test
+    fun buildsLatestV3BundleUrl() {
+        assertEquals(
+            "https://${ExternalBundlesEndpoints.DEV_HOST}/api/v3/bundle" +
+                "?source_url=https%3A%2F%2Fgithub.com%2Fcrimera%2Fpiko" +
+                "&version=latest&channel=prerelease",
+            ExternalBundlesEndpoints.latestBundleUrl(
+                host = ExternalBundlesEndpoints.DEV_HOST,
+                sourceUrl = "https://github.com/crimera/piko/",
+                prerelease = true
+            )
+        )
+    }
+
+    @Test
+    fun acceptsV3AndLegacyBundlePaths() {
+        assertTrue(ExternalBundlesEndpoints.isBundleApiPath("/api/v3/bundle"))
+        assertTrue(ExternalBundlesEndpoints.isBundleApiPath("/api/v2/bundle/owner/repo/latest"))
+        assertTrue(ExternalBundlesEndpoints.isBundleApiPath("/bundles/id"))
+    }
+
+    @Test
+    fun buildsSiteUrlForActiveHost() {
+        assertEquals(
+            "https://${ExternalBundlesEndpoints.DEV_HOST}/",
+            ExternalBundlesEndpoints.siteUrl(ExternalBundlesEndpoints.DEV_HOST)
+        )
+        assertEquals(
+            "https://${ExternalBundlesEndpoints.STABLE_HOST}/",
+            ExternalBundlesEndpoints.siteUrl("unknown.example.com")
+        )
+    }
+
+    @Test
+    fun returnsAlternateHost() {
+        assertEquals(
+            ExternalBundlesEndpoints.DEV_HOST,
+            ExternalBundlesEndpoints.alternateHost(ExternalBundlesEndpoints.STABLE_HOST)
+        )
+        assertEquals(
+            ExternalBundlesEndpoints.STABLE_HOST,
+            ExternalBundlesEndpoints.alternateHost(ExternalBundlesEndpoints.DEV_HOST.uppercase())
+        )
+        assertNull(ExternalBundlesEndpoints.alternateHost("unknown.example.com"))
+        assertNull(ExternalBundlesEndpoints.alternateHost(null))
+    }
+}

--- a/app/src/test/java/app/urv/manager/network/api/ExternalBundlesEndpointsTest.kt
+++ b/app/src/test/java/app/urv/manager/network/api/ExternalBundlesEndpointsTest.kt
@@ -52,4 +52,38 @@ class ExternalBundlesEndpointsTest {
         assertNull(ExternalBundlesEndpoints.alternateHost("unknown.example.com"))
         assertNull(ExternalBundlesEndpoints.alternateHost(null))
     }
+
+    @Test
+    fun selectsHostWithNewestApiRelease() {
+        assertEquals(
+            ExternalBundlesEndpoints.DEV_HOST,
+            ExternalBundlesEndpoints.preferredHost(
+                stableVersion = "1.2.0",
+                devVersion = "1.3.0-dev.3"
+            )
+        )
+        assertEquals(
+            ExternalBundlesEndpoints.STABLE_HOST,
+            ExternalBundlesEndpoints.preferredHost(
+                stableVersion = "1.3.0",
+                devVersion = "1.3.0-dev.3"
+            )
+        )
+    }
+
+    @Test
+    fun selectsWorkingHostWhenVersionMetadataIsUnavailable() {
+        assertEquals(
+            ExternalBundlesEndpoints.DEV_HOST,
+            ExternalBundlesEndpoints.preferredHost(stableVersion = null, devVersion = "1.3.0-dev.3")
+        )
+        assertEquals(
+            ExternalBundlesEndpoints.STABLE_HOST,
+            ExternalBundlesEndpoints.preferredHost(stableVersion = "1.2.0", devVersion = null)
+        )
+        assertEquals(
+            ExternalBundlesEndpoints.DEV_HOST,
+            ExternalBundlesEndpoints.preferredHost(stableVersion = null, devVersion = null)
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Query the stable and dev external-bundle services concurrently and select the service with the newest bundle data.
- Keep pagination and patch-detail requests tied to the selected service, with identity-based fallback when service-local IDs differ.
- Generate v3 bundle URLs for imports while retaining compatibility with existing v1, v2, and legacy bundle URLs.
- Merge bundle history across both services and prevent cross-service numeric ID collisions when detecting imported bundles.

## Why

The stable service can be unavailable or behind the dev service. Previously, a successful stable response was preferred even when dev had newer data. Bundle IDs are also local to each service, so treating matching numeric IDs as the same bundle could display incorrect imported or patch information.

## Testing

- [x] `git diff --check`
- [x] `.\gradlew.bat assembleRelease`
- [x] Confirmed that both services accept v3 bundle URLs.
- [x] Confirmed that both GraphQL endpoints expose the bundle and refresh timestamps used for freshness selection.
- [x] Verify discovery, searching, pagination, and patch details with both services available.
- [x] Make the stable service unavailable and verify discovery, patch details, and imports fall back to dev.
- [x] Import a discovered bundle, restart the app, and verify update checks continue using the correct v3 endpoint.
- [x] Verify a legacy bundle from one service does not mark an unrelated bundle with the same numeric ID from the other service as imported.